### PR TITLE
highlighting active file in project explorer

### DIFF
--- a/solarized_template.theme.json
+++ b/solarized_template.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#<inverse_emphasized_content>",
       "selectionForeground": "#<inverse_background>",
-      "selectionInactiveBackground": "#<background_highlights>",
-      "selectionBackgroundInactive": "#<background_highlights>",
+      "selectionInactiveBackground": "#<background_highlights_shade_1>",
+      "selectionBackgroundInactive": "#<background_highlights_shade_1>",
 
       "lightSelectionBackground": "#<background_highlights_shade_1>",
       "lightSelectionForeground": "#<primary_text>",

--- a/src/solarized_dark_theme.theme.json
+++ b/src/solarized_dark_theme.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#586e75",
       "selectionForeground": "#fdf6e3",
-      "selectionInactiveBackground": "#073642",
-      "selectionBackgroundInactive": "#073642",
+      "selectionInactiveBackground": "#074855",
+      "selectionBackgroundInactive": "#074855",
 
       "lightSelectionBackground": "#074855",
       "lightSelectionForeground": "#839496",

--- a/src/solarized_light_theme.theme.json
+++ b/src/solarized_light_theme.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#93a1a1",
       "selectionForeground": "#002b36",
-      "selectionInactiveBackground": "#eee8d5",
-      "selectionBackgroundInactive": "#eee8d5",
+      "selectionInactiveBackground": "#cdc8b7",
+      "selectionBackgroundInactive": "#cdc8b7",
 
       "lightSelectionBackground": "#cdc8b7",
       "lightSelectionForeground": "#657b83",


### PR DESCRIPTION
I severly missed that the file I am currently editing is not highlighted in the project explorer. This change fixes that.

While project explorer has focus:
<img width="544" alt="Screenshot 2019-07-30 at 09 28 58" src="https://user-images.githubusercontent.com/71494/62109527-c0c89280-b2ac-11e9-89f7-8e5e360c5377.png">

When project explorer does not have focus, e.g. when I em editing the file in the editor...
<img width="544" alt="Screenshot 2019-07-30 at 09 29 03" src="https://user-images.githubusercontent.com/71494/62109561-d3db6280-b2ac-11e9-9350-66ef23feccba.png">
