### PR TITLE
Restyle tabs 2019.2

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -31,7 +31,7 @@
   </change-notes>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="191.0"/>
+  <idea-version since-build="192.0"/>
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->

--- a/solarized_template.theme.json
+++ b/solarized_template.theme.json
@@ -111,7 +111,16 @@
 
     "DebuggerPopup.borderColor": "#524e66",
 
-    "DebuggerTabs.selectedBackground": "#<background_highlights_shade_1>",
+    "DefaultTabs": {
+      "background": "#<background_highlights_shade_1>",
+      "borderColor": "#<background_highlights_shade_1>",
+      "hoverBackground": "#<background_highlights_shade_2>",
+      "inactiveUnderlineColor": "#<background_highlights>",
+      "underlineColor": "#<background_highlights_shade_2>",
+      "underlinedTabBackground": "#<background_highlights>",
+      "underlinedTabForeground": "#<primary_text>",
+      "underlineHeight": 5
+    },
 
     "DragAndDrop": {
       "areaForeground": "#<primary_text>",
@@ -128,11 +137,15 @@
     "EditorPane.inactiveBackground": "#<background>",
 
     "EditorTabs": {
-      "selectedForeground": "#<primary_text>",
-      "selectedBackground": "#<background_highlights>",
-      "underlineColor": "#<emphasized_content>",
-      "inactiveMaskColor": "#<mask_color>33",
-      "borderColor": "#<primary_text>"
+      "borderColor": "#<background_highlights>",
+      "underlineColor": "#<background_highlights_shade_2>",
+      "inactiveUnderlineColor":  "#<background_highlights_shade_2>",
+      "background": "#<background_highlights_shade_1>",
+      "underlinedTabBackground": "#<background_highlights>",
+      "hoverMaskColor": "#<background_highlights_shade_2>",
+      "underlinedTabForeground": "#<primary_text>",
+      "inactiveColoredFileBackground": "#<background_highlights_shade_1>",
+      "underlineHeight": 5
     },
 
     "FileColor": {
@@ -189,12 +202,6 @@
     },
 
     "Plugins": {
-      "Tab": {
-        "selectedForeground": "#<primary_text>",
-        "selectedBackground": "#<background_highlights_shade_1>",
-        "hoverBackground": "#<background_highlights_shade_1>"
-      },
-
       "SearchField.borderColor": "#<emphasized_content>",
       "SearchField.background": "#<background>",
       "SectionHeader.background": "#<background_highlights>",
@@ -270,9 +277,14 @@
     "StatusBar.borderColor": "#1a1721",
 
     "TabbedPane": {
-      "underlineColor": "#073642",
-      "disabledUnderlineColor": "#5e5b6b",
-      "contentAreaColor": "#1a1721"
+      "underlineColor": "#<background_highlights_shade_2>",
+      "disabledUnderlineColor": "#<background_highlights_shade_2>",
+      "contentAreaColor": "#<background_highlights>",
+      "background": "#<background_highlights_shade_1>",
+      "foreground": "#<primary_text>",
+      "disabledForeground": "#<primary_text>",
+      "focusColor": "#<background_highlights>",
+      "hoverColor": "#<background_highlights_shade_2>"
     },
 
     "TableHeader.cellBorder": "3,0,3,0",

--- a/solarized_template.theme.json
+++ b/solarized_template.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#<inverse_emphasized_content>",
       "selectionForeground": "#<inverse_background>",
-      "selectionInactiveBackground": "#<background_highlights>",
-      "selectionBackgroundInactive": "#<background_highlights>",
+      "selectionInactiveBackground": "#<background_highlights_shade_1>",
+      "selectionBackgroundInactive": "#<background_highlights_shade_1>",
 
       "lightSelectionBackground": "#<background_highlights_shade_1>",
       "lightSelectionForeground": "#<primary_text>",

--- a/solarized_template.theme.json
+++ b/solarized_template.theme.json
@@ -115,7 +115,7 @@
       "background": "#<background_highlights_shade_1>",
       "borderColor": "#<background_highlights_shade_1>",
       "hoverBackground": "#<background_highlights_shade_2>",
-      "inactiveUnderlineColor": "#<background_highlights>",
+      "inactiveUnderlineColor": "#<background_highlights_shade_2>",
       "underlineColor": "#<background_highlights_shade_2>",
       "underlinedTabBackground": "#<background_highlights>",
       "underlinedTabForeground": "#<primary_text>",

--- a/solarized_template.theme.json
+++ b/solarized_template.theme.json
@@ -138,14 +138,14 @@
 
     "EditorTabs": {
       "borderColor": "#<background_highlights>",
-      "underlineColor": "#<background_highlights_shade_2>",
-      "inactiveUnderlineColor":  "#<background_highlights_shade_2>",
+      "underlineColor": "#<background_highlights>",
+      "inactiveUnderlineColor":  "#<background>",
       "background": "#<background_highlights_shade_1>",
-      "underlinedTabBackground": "#<background_highlights>",
+      "underlinedTabBackground": "#<background>",
       "hoverMaskColor": "#<background_highlights_shade_2>",
       "underlinedTabForeground": "#<primary_text>",
       "inactiveColoredFileBackground": "#<background_highlights_shade_1>",
-      "underlineHeight": 5
+      "underlineHeight": 0
     },
 
     "FileColor": {
@@ -191,6 +191,10 @@
         "errorBackground": "#802d43",
         "errorBorderColor": "#4d1c2b"
       }
+    },
+
+    "Panel": {
+      "background": "#<background>"
     },
 
     "ParameterInfo": {

--- a/src/solarized_dark_theme.theme.json
+++ b/src/solarized_dark_theme.theme.json
@@ -115,7 +115,7 @@
       "background": "#074855",
       "borderColor": "#074855",
       "hoverBackground": "#0A677A",
-      "inactiveUnderlineColor": "#073642",
+      "inactiveUnderlineColor": "#0A677A",
       "underlineColor": "#0A677A",
       "underlinedTabBackground": "#073642",
       "underlinedTabForeground": "#839496",

--- a/src/solarized_dark_theme.theme.json
+++ b/src/solarized_dark_theme.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#586e75",
       "selectionForeground": "#fdf6e3",
-      "selectionInactiveBackground": "#073642",
-      "selectionBackgroundInactive": "#073642",
+      "selectionInactiveBackground": "#074855",
+      "selectionBackgroundInactive": "#074855",
 
       "lightSelectionBackground": "#074855",
       "lightSelectionForeground": "#839496",

--- a/src/solarized_dark_theme.theme.json
+++ b/src/solarized_dark_theme.theme.json
@@ -138,14 +138,14 @@
 
     "EditorTabs": {
       "borderColor": "#073642",
-      "underlineColor": "#0A677A",
-      "inactiveUnderlineColor":  "#0A677A",
+      "underlineColor": "#073642",
+      "inactiveUnderlineColor":  "#002b36",
       "background": "#074855",
-      "underlinedTabBackground": "#073642",
+      "underlinedTabBackground": "#002b36",
       "hoverMaskColor": "#0A677A",
       "underlinedTabForeground": "#839496",
       "inactiveColoredFileBackground": "#074855",
-      "underlineHeight": 5
+      "underlineHeight": 0
     },
 
     "FileColor": {
@@ -191,6 +191,10 @@
         "errorBackground": "#802d43",
         "errorBorderColor": "#4d1c2b"
       }
+    },
+
+    "Panel": {
+      "background": "#002b36"
     },
 
     "ParameterInfo": {

--- a/src/solarized_dark_theme.theme.json
+++ b/src/solarized_dark_theme.theme.json
@@ -111,7 +111,16 @@
 
     "DebuggerPopup.borderColor": "#524e66",
 
-    "DebuggerTabs.selectedBackground": "#074855",
+    "DefaultTabs": {
+      "background": "#074855",
+      "borderColor": "#074855",
+      "hoverBackground": "#0A677A",
+      "inactiveUnderlineColor": "#073642",
+      "underlineColor": "#0A677A",
+      "underlinedTabBackground": "#073642",
+      "underlinedTabForeground": "#839496",
+      "underlineHeight": 5
+    },
 
     "DragAndDrop": {
       "areaForeground": "#839496",
@@ -128,11 +137,15 @@
     "EditorPane.inactiveBackground": "#002b36",
 
     "EditorTabs": {
-      "selectedForeground": "#839496",
-      "selectedBackground": "#073642",
-      "underlineColor": "#93a1a1",
-      "inactiveMaskColor": "#0d0d0d33",
-      "borderColor": "#839496"
+      "borderColor": "#073642",
+      "underlineColor": "#0A677A",
+      "inactiveUnderlineColor":  "#0A677A",
+      "background": "#074855",
+      "underlinedTabBackground": "#073642",
+      "hoverMaskColor": "#0A677A",
+      "underlinedTabForeground": "#839496",
+      "inactiveColoredFileBackground": "#074855",
+      "underlineHeight": 5
     },
 
     "FileColor": {
@@ -189,12 +202,6 @@
     },
 
     "Plugins": {
-      "Tab": {
-        "selectedForeground": "#839496",
-        "selectedBackground": "#074855",
-        "hoverBackground": "#074855"
-      },
-
       "SearchField.borderColor": "#93a1a1",
       "SearchField.background": "#002b36",
       "SectionHeader.background": "#073642",
@@ -270,9 +277,14 @@
     "StatusBar.borderColor": "#1a1721",
 
     "TabbedPane": {
-      "underlineColor": "#073642",
-      "disabledUnderlineColor": "#5e5b6b",
-      "contentAreaColor": "#1a1721"
+      "underlineColor": "#0A677A",
+      "disabledUnderlineColor": "#0A677A",
+      "contentAreaColor": "#073642",
+      "background": "#074855",
+      "foreground": "#839496",
+      "disabledForeground": "#839496",
+      "focusColor": "#073642",
+      "hoverColor": "#0A677A"
     },
 
     "TableHeader.cellBorder": "3,0,3,0",

--- a/src/solarized_light_theme.theme.json
+++ b/src/solarized_light_theme.theme.json
@@ -111,7 +111,16 @@
 
     "DebuggerPopup.borderColor": "#524e66",
 
-    "DebuggerTabs.selectedBackground": "#cdc8b7",
+    "DefaultTabs": {
+      "background": "#cdc8b7",
+      "borderColor": "#cdc8b7",
+      "hoverBackground": "#A4A092",
+      "inactiveUnderlineColor": "#eee8d5",
+      "underlineColor": "#A4A092",
+      "underlinedTabBackground": "#eee8d5",
+      "underlinedTabForeground": "#657b83",
+      "underlineHeight": 5
+    },
 
     "DragAndDrop": {
       "areaForeground": "#657b83",
@@ -128,11 +137,15 @@
     "EditorPane.inactiveBackground": "#fdf6e3",
 
     "EditorTabs": {
-      "selectedForeground": "#657b83",
-      "selectedBackground": "#eee8d5",
-      "underlineColor": "#586e75",
-      "inactiveMaskColor": "#b5890033",
-      "borderColor": "#657b83"
+      "borderColor": "#eee8d5",
+      "underlineColor": "#A4A092",
+      "inactiveUnderlineColor":  "#A4A092",
+      "background": "#cdc8b7",
+      "underlinedTabBackground": "#eee8d5",
+      "hoverMaskColor": "#A4A092",
+      "underlinedTabForeground": "#657b83",
+      "inactiveColoredFileBackground": "#cdc8b7",
+      "underlineHeight": 5
     },
 
     "FileColor": {
@@ -189,12 +202,6 @@
     },
 
     "Plugins": {
-      "Tab": {
-        "selectedForeground": "#657b83",
-        "selectedBackground": "#cdc8b7",
-        "hoverBackground": "#cdc8b7"
-      },
-
       "SearchField.borderColor": "#586e75",
       "SearchField.background": "#fdf6e3",
       "SectionHeader.background": "#eee8d5",
@@ -270,9 +277,14 @@
     "StatusBar.borderColor": "#1a1721",
 
     "TabbedPane": {
-      "underlineColor": "#073642",
-      "disabledUnderlineColor": "#5e5b6b",
-      "contentAreaColor": "#1a1721"
+      "underlineColor": "#A4A092",
+      "disabledUnderlineColor": "#A4A092",
+      "contentAreaColor": "#eee8d5",
+      "background": "#cdc8b7",
+      "foreground": "#657b83",
+      "disabledForeground": "#657b83",
+      "focusColor": "#eee8d5",
+      "hoverColor": "#A4A092"
     },
 
     "TableHeader.cellBorder": "3,0,3,0",

--- a/src/solarized_light_theme.theme.json
+++ b/src/solarized_light_theme.theme.json
@@ -13,8 +13,8 @@
 
       "selectionBackground": "#93a1a1",
       "selectionForeground": "#002b36",
-      "selectionInactiveBackground": "#eee8d5",
-      "selectionBackgroundInactive": "#eee8d5",
+      "selectionInactiveBackground": "#cdc8b7",
+      "selectionBackgroundInactive": "#cdc8b7",
 
       "lightSelectionBackground": "#cdc8b7",
       "lightSelectionForeground": "#657b83",

--- a/src/solarized_light_theme.theme.json
+++ b/src/solarized_light_theme.theme.json
@@ -138,14 +138,14 @@
 
     "EditorTabs": {
       "borderColor": "#eee8d5",
-      "underlineColor": "#A4A092",
-      "inactiveUnderlineColor":  "#A4A092",
+      "underlineColor": "#eee8d5",
+      "inactiveUnderlineColor":  "#fdf6e3",
       "background": "#cdc8b7",
-      "underlinedTabBackground": "#eee8d5",
+      "underlinedTabBackground": "#fdf6e3",
       "hoverMaskColor": "#A4A092",
       "underlinedTabForeground": "#657b83",
       "inactiveColoredFileBackground": "#cdc8b7",
-      "underlineHeight": 5
+      "underlineHeight": 0
     },
 
     "FileColor": {
@@ -191,6 +191,10 @@
         "errorBackground": "#802d43",
         "errorBorderColor": "#4d1c2b"
       }
+    },
+
+    "Panel": {
+      "background": "#fdf6e3"
     },
 
     "ParameterInfo": {

--- a/src/solarized_light_theme.theme.json
+++ b/src/solarized_light_theme.theme.json
@@ -115,7 +115,7 @@
       "background": "#cdc8b7",
       "borderColor": "#cdc8b7",
       "hoverBackground": "#A4A092",
-      "inactiveUnderlineColor": "#eee8d5",
+      "inactiveUnderlineColor": "#A4A092",
       "underlineColor": "#A4A092",
       "underlinedTabBackground": "#eee8d5",
       "underlinedTabForeground": "#657b83",


### PR DESCRIPTION
This commit improves the styling of tabs throughout the IDE based on new feature/properties that can be accessed starting with intellij 2019.2.

Screenshots:

Editor tabs before:
<img width="754" alt="Screenshot 2019-07-30 at 16 21 52" src="https://user-images.githubusercontent.com/71494/62138696-59303880-b2e8-11e9-890e-c6b886f5bc52.png">

Editor tabs after:
<img width="654" alt="Screenshot 2019-08-09 at 21 08 38" src="https://user-images.githubusercontent.com/71494/62803213-1d685080-baea-11e9-8411-e7d62dd2cf0d.png">


Run targets/logs before:
<img width="518" alt="Screenshot 2019-07-30 at 16 31 00" src="https://user-images.githubusercontent.com/71494/62138747-7402ad00-b2e8-11e9-848e-c890359a2763.png">

Run targets/logs after:
<img width="518" alt="Screenshot 2019-07-30 at 16 28 52" src="https://user-images.githubusercontent.com/71494/62138768-7d8c1500-b2e8-11e9-9ecf-3c32b1950517.png">

Tab pane before:
<img width="805" alt="Screenshot 2019-07-30 at 16 31 40" src="https://user-images.githubusercontent.com/71494/62138820-91377b80-b2e8-11e9-8084-eaf2935cfcd1.png">

Tab pane after:
<img width="805" alt="Screenshot 2019-07-30 at 16 33 40" src="https://user-images.githubusercontent.com/71494/62138829-985e8980-b2e8-11e9-84d7-8c1159c86977.png">
