### PR TITLE
using darcula as base for dark theme

### DIFF
--- a/resources/themes/solarizedDark.xml
+++ b/resources/themes/solarizedDark.xml
@@ -1,4 +1,4 @@
-<scheme name="Solarized Dark" version="142" parent_scheme="Default">
+<scheme name="Solarized Dark" version="142" parent_scheme="Darcula">
   <metaInfo>
     <property name="created">2019-03-16T23:34:56</property>
     <property name="ide">idea</property>


### PR DESCRIPTION
does not result in apparent changes, but helps plugins having ui changes depending on if a dark theme is used or not (such as rainbow brackets).